### PR TITLE
Upgrade to Moodle 2.9 API, use core_text.

### DIFF
--- a/lang/en/plagiarism_moss.php
+++ b/lang/en/plagiarism_moss.php
@@ -117,7 +117,7 @@ $string['tag'] = 'Tag';
 $string['tag_help'] = 'Different activities using the same tag will be measured together. Tag is helpful to prevent plagiarism among courses.';
 $string['timesubmitted'] ='Time submitted';
 $string['timetomeasure'] ='Time to measure';
-$string['timetomeasure_help'] ='Set the time to measure all submissions to detect plagiarism. If not set, the measure will occur after the activity\'s due time.
+$string['timetomeasure_help'] ='Set the time to measure all submissions to detect plagiarism.
 
 The measure will be executed only once against all existing submissions. If you want to measure again, reset the time.';
 

--- a/lib.php
+++ b/lib.php
@@ -163,7 +163,7 @@ class plagiarism_plugin_moss extends plagiarism_plugin {
 
         $mform->addElement('checkbox', 'enabled', get_string('mossenabled', 'plagiarism_moss'));
 
-        $mform->addElement('date_time_selector', 'timetomeasure', get_string('timetomeasure', 'plagiarism_moss'), array('optional' => true));
+        $mform->addElement('date_time_selector', 'timetomeasure', get_string('timetomeasure', 'plagiarism_moss'));
         $mform->addHelpButton('timetomeasure', 'timetomeasure', 'plagiarism_moss');
         $mform->disabledIf('timetomeasure', 'enabled');
 

--- a/locallib.php
+++ b/locallib.php
@@ -98,26 +98,28 @@ function moss_save_storedfiles($storedfiles, $cmid, $userid) {
     }
 
     // store files
-    foreach($storedfiles as $file) {
-        if ($file->get_filename() === '.') {
-            continue;
-        }
-        //hacky way to check file still exists
-        $fileid = $fs->get_file_by_id($file->get_id());
-        if (empty($fileid)) {
-            mtrace("nofilefound!");
-            continue;
-        }
+    foreach($storedfiles as $fileMultiple) {
+        foreach($fileMultiple as $file) {
+            if ($file->get_filename() === '.') {
+                continue;
+            }
+            //hacky way to check file still exists
+            $fileid = $fs->get_file_by_id($file->get_id());
+            if (empty($fileid)) {
+                mtrace("nofilefound!");
+                continue;
+            }
 
-        $fileinfo = array(
-            'contextid' => $context->id,
-            'component' => 'plagiarism_moss',
-            'filearea'  => 'files',
-            'itemid'    => $cmid,
-            'filepath'  => "/$userid/",
-            // save /abc/def/ghi.c as abc_def_ghi.c
-            'filename'  => str_replace('/', '_', ltrim($file->get_filepath(), '/')).$file->get_filename());
-        $fs->create_file_from_storedfile($fileinfo, $file);
+            $fileinfo = array(
+                'contextid' => $context->id,
+                'component' => 'plagiarism_moss',
+                'filearea'  => 'files',
+                'itemid'    => $cmid,
+                'filepath'  => "/$userid/",
+                // save /abc/def/ghi.c as abc_def_ghi.c
+                'filename'  => str_replace('/', '_', ltrim($file->get_filepath(), '/')).$file->get_filename());
+            $fs->create_file_from_storedfile($fileinfo, $file);
+        }
     }
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -241,7 +241,7 @@ function moss_get_supported_languages() {
         'vhdl'    => 'VHDL',
         'vb'      => 'Visual Basic');
 
-    textlib_get_instance()->asort($langs);
+    core_collator::asort($langs);
     return $langs;
 }
 

--- a/moss.php
+++ b/moss.php
@@ -156,7 +156,7 @@ class moss {
                 $content = pdf2text($temp_file);
                 break;
             case '.rtf':
-                $content = textlib_get_instance()->entities_to_utf8(rtf2text($temp_file));
+                $content = core_text::entities_to_utf8(rtf2text($temp_file));
                 break;
             case '.odt':
                 $content =  getTextFromZippedXML($temp_file,'content.xml');
@@ -168,11 +168,11 @@ class moss {
                     // It is really a docx
                     $content = getTextFromZippedXML($temp_file,'word/document.xml');
                 } else if (empty($antiwordpath) || !is_executable($antiwordpath)) {
-                    $content = textlib_get_instance()->entities_to_utf8(doc2text($temp_file));
+                    $content = core_text::entities_to_utf8(doc2text($temp_file));
                 } else {
                     $content = shell_exec($antiwordpath.' -f -w 0 '.escapeshellarg($temp_file));
                     if (empty($content)) { // antiword can not recognize this file
-                        $content = textlib_get_instance()->entities_to_utf8(doc2text($temp_file));
+                        $content = core_text::entities_to_utf8(doc2text($temp_file));
                     }
                 }
                 break;
@@ -190,7 +190,7 @@ class moss {
         if (!mb_check_encoding($content, 'UTF-8')) {
             if (mb_check_encoding($content, $localewincharset)) {
                 // Convert content charset to UTF-8
-                $content = textlib_get_instance()->convert($content, $localewincharset);
+                $content = core_text::convert($content, $localewincharset);
             } else {
                 // Unknown charset, possible binary file. Skip it
                 mtrace("\tSkip unknown charset/binary file ".$file->get_filepath().$file->get_filename());


### PR DESCRIPTION
Moodle 2.9 requires using core_text:::xxx functions. Right now entering plagiarism/moss/settings.php page fails with error 

textlib_get_instance() can not be used any more, please use core_text::functioname() instead.

Submitting a simple fix. Other Moodle modules applied similar fixes, see e.g. https://github.com/patrickpollet/moodle_local_ldap/issues/9 and https://github.com/jleyva/moodle-local_ltiprovider/commit/9fefa6b2572b899575de83596b48d390344b26ad .

This fix seems to work fine for our Moodle 2.9.2+ (from 2015-09-18) installation + Moss.
